### PR TITLE
Bump actions/checkout in generated workflows

### DIFF
--- a/pkgs/github-workflows/default.nix
+++ b/pkgs/github-workflows/default.nix
@@ -68,7 +68,7 @@ let
           - uses: purcell/setup-emacs@master
             with:
               version: ''${{ matrix.emacs_version }}
-          - uses: actions/checkout@v2
+          - uses: actions/checkout@v3
           - name: Install dependencies
             run: |
               cat <(jq -r '.nodes.root.inputs | map(.) | .[]' ${lockDirName}/flake.lock) \


### PR DESCRIPTION
If this version is outdated, dependabot creates a PR for updating generated workflows.

I think it is a bad idea to generate workflows. I will create an action repository for nomake.