### PR TITLE
Revert "ci: Allow updating the inputs from webhooks"

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,8 +3,6 @@ name: Update dependencies
 on:
   schedule:
     - cron: '0 5 * * *'
-  repository_dispatch:
-    types: [update_inputs]
 
 jobs:
   update:


### PR DESCRIPTION
Revert #24. GitHub Actions can trigger workflows in other repositories.